### PR TITLE
Add additional advisory options when using ATCF/Best Track style wind forcing, new ADCIRCPy specific warnings, user-defined namelists, and minimal SWAN support.

### DIFF
--- a/adcircpy/driver.py
+++ b/adcircpy/driver.py
@@ -410,6 +410,9 @@ class AdcircRun(Fort15):
             script = DriverFile(self, nproc)
             script.write(output_directory / driver, overwrite)
 
+        if self.wave_forcing is not None:
+            self.wave_forcing.write(output_directory,overwrite)
+
     def import_stations(
         self,
         fort15: os.PathLike,

--- a/adcircpy/forcing/waves/__init__.py
+++ b/adcircpy/forcing/waves/__init__.py
@@ -1,7 +1,9 @@
 from adcircpy.forcing.waves.base import WaveForcing
 from adcircpy.forcing.waves.ww3 import WaveWatch3DataForcing
+from adcircpy.forcing.waves.swan import SWANForcing
 
 __all__ = [
     'WaveForcing',
     'WaveWatch3DataForcing',
+    'SWANForcing',
 ]

--- a/adcircpy/forcing/waves/swan.py
+++ b/adcircpy/forcing/waves/swan.py
@@ -1,0 +1,21 @@
+from os import PathLike
+from pathlib import Path
+
+from adcircpy.forcing.waves import WaveForcing
+
+import warnings
+
+from adcircpy.warnings import warn_adcirc, UnsupportedFeatureWarning
+
+class SWANForcing(WaveForcing):
+    def __init__(self, nrs: int = 3, \
+            interval_seconds: int = 600):
+        super().__init__(nrs=nrs, interval_seconds=interval_seconds)
+
+    def write(self, directory: PathLike, overwrite: bool = False):
+        txt=f'ADCIRCPy does not currently support writing '\
+                +f'coupled ADCIRC+SWAN input files (fort.26 and swaninit). '\
+                +f'User will have to create these files themselves to run '\
+                +f'padcswan.'
+        warn_adcirc(txt, UnsupportedFeatureWarning)
+        pass

--- a/adcircpy/fort15.py
+++ b/adcircpy/fort15.py
@@ -1003,7 +1003,7 @@ class Fort15:
     @property
     def RUNDES(self) -> str:
         try:
-            self.__RUNDES
+            return self.__RUNDES
         except AttributeError:
             return datetime.now().strftime('created on %Y-%m-%d %H:%M')
 
@@ -1014,7 +1014,7 @@ class Fort15:
     @property
     def RUNID(self) -> str:
         try:
-            self.__RUNID
+            return self.__RUNID
         except AttributeError:
             return self.mesh.description
 

--- a/adcircpy/warnings.py
+++ b/adcircpy/warnings.py
@@ -1,0 +1,35 @@
+import warnings
+
+class ADCIRCPyWarning(UserWarning):
+    '''
+    base adcircpy warning class
+    '''
+    pass
+
+class UnsupportedFeatureWarning(ADCIRCPyWarning):
+    '''
+    Feature exists in ADCIRC but is not yet supported by adcircpy
+    '''
+    pass
+
+class ModelSetupWarning(ADCIRCPyWarning):
+    '''
+    Indicates a configuration or setup issue in adcircpy inputs
+    '''
+    pass
+
+def warn_adcirc(message, category=ADCIRCPyWarning, stacklevel=2):
+    '''
+    Prints a standardized warning message
+
+    Parameters
+    ----------
+    message: str
+        The warning message to display
+    category: Warning subclass, optional
+        The type of warning to issue (defaults to ADCIRCPyWarning)
+    stacklevel : int, optional
+        The stack level for the warning location
+    '''
+    clean_message = (message.strip()).rstrip(".") + "."
+    warnings.warn(clean_message, category, stacklevel=stacklevel)


### PR DESCRIPTION
This pull request adds capability to ADCIRCPy to support additional ADCIRC capabilities and provide users with warnings for partially implemented features.

- **BestTrackForcing enhancements**
   - Add `file_deck` and `advisories` as optional parameters to BestTrackForcing class. By default these parameters preserve the legacy behavior but allow the user more control if using ATCF/NHC advisories other than the best track.
- **New ADCIRCPy-specific warning system**
   - Introduce `adcircpy/warnings.py` which creates custom classes of warnings to better notify users of issues. These new warnings are:
      - `ADCIRCPyWarning`: Base class forADCIRCPy-specific warnings.
      - `UnsupportedFeatureWarning`: Warns about features that are present in ADCIRC but are not fully supported by ADCIRCPy (e.g., Warns the user that ADCIRCPy will not (presently) write out SWAN specific input files if SWAN is activated).
      - `ModelSetupWarning`: Indicates that there is an issue with inputs to ADCIRCPy (e.g., Warns the user when `NTIP=2` but no self-attraction/loading (fort.24) data is present).
- **Initial SWAN forcing support**
   - Add `adcircpy/forcing/waves/swan.py`: Adds SWAN wave model forcing as a type of forcing. 
   - At present ADCIRCPy will not generate SWAN input files and users will be notified if this unsupported feature.
- **Custom namelist support**
   - Extend the Fort15 class to allow users to create, modify, and add custom namelists not present by default.
   - Provide flexibility without modifying core code.

**Notes**
   - All changes backwards compatible.
   - New warnings are non-fatal and are designed to improve user awareness of unsupported or incomplete features.